### PR TITLE
! Fix Firefox and Safari glitches.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/Coveo/styleguide.git"
   },
   "devDependencies": {
-    "coveo-slider": "0.9.4",
+    "coveo-slider": "0.9.7",
     "csscomb": "3.1.8",
     "del": "2.0.2",
     "gulp": "3.9.0",

--- a/scss/_reset.scss
+++ b/scss/_reset.scss
@@ -1,9 +1,0 @@
-body {
-  margin: 0;
-}
-img {
-  max-width: 100%;
-}
-svg {
-  max-height: 100%;
-}

--- a/scss/controls/dropdown.scss
+++ b/scss/controls/dropdown.scss
@@ -7,7 +7,7 @@
     display: inline-block;
 
     text-transform: initial;
-
+    white-space: normal;
     .dropdown-toggle-arrow {
       float: right;
       margin-top: -5px;

--- a/scss/elements/btn.scss
+++ b/scss/elements/btn.scss
@@ -21,7 +21,6 @@
   }
 }
 
-
 .btn {
   display: inline-block;
   height: $button-height;
@@ -50,8 +49,13 @@
 
   &:hover, &:focus {
     text-decoration: none;
+  }
 
+  &:focus {
     background-color: $light-grey;
+    outline: thin dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
   }
 
   &:disabled, &.state-disabled {

--- a/scss/lib/reset.scss
+++ b/scss/lib/reset.scss
@@ -14,6 +14,16 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
   border: 0;
 }
 
+html {
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  height: 100%;
+  overflow: auto;
+}
+
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
   display: block;
@@ -39,4 +49,10 @@ blockquote:before, blockquote:after, q:before, q:after {
 table {
   border-collapse: inherit;
   border-spacing: 0;
+}
+
+button::-moz-focus-inner, input::-moz-focus-inner {
+  padding: 0;
+
+  border: 0;
 }


### PR DESCRIPTION
* Bump version of slider containing fixes for Firefox outline.
* Merge the two reset.scss files together.
* Add -moz-focus-inner reset by normalize.css
* Fix outline on buttons to have the "native" feel
* Fix dropdown icon align