### PR TITLE
! Fix collapsible z-index

### DIFF
--- a/scss/controls/collapsable.scss
+++ b/scss/controls/collapsable.scss
@@ -50,7 +50,6 @@
         position: absolute;
         top: 8px;
         left: 10px;
-        z-index: -1;
 
         display: inline-block;
 


### PR DESCRIPTION
I guess z-index was there for a reason? But it doesn't show up in the license panel and removing it still works in all sources panels...
Let me know if you know why there was a z-index: -1;