### PR TITLE
Input tweaks

### DIFF
--- a/docs/_components/form_controls/01_input.html
+++ b/docs/_components/form_controls/01_input.html
@@ -12,7 +12,20 @@ stylesheet: '/scss/elements/input-field.scss'
 
     <div class="input-field form-group">
         <input type="text" required placeholder="Placeholder text"/>
-        <label>Enabled invalid input</label>
+        <label>
+            Enabled invalid input
+            <span class="inline-help-tooltip" title="A simple inline help text." data-placement="right">
+                <span class="inline-help-icon">
+                    <svg viewBox="0 0 20 20" class="icon fill-medium-grey">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                              d="M10 4.6c-2 0-3.7 1.6-3.7 3.7h1.8c0-1 .8-1.8 1.8-1.8s1.8.8 1.8 1.8c0 1.8-2.8 1.6-2.8 4.6h1.8c0-2.1 2.8-2.3 2.8-4.6.2-2.1-1.5-3.7-3.5-3.7z"></path>
+                        <path d="M9.1 13.8h1.8v1.8H9.1z"></path>
+                        <path d="M10 17.2c-4 0-7.2-3.2-7.2-7.2S6 2.8 10 2.8 17.2 6 17.2 10 14 17.2 10 17.2zM10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9z"
+                              clip-rule="evenodd" fill-rule="evenodd"></path>
+                    </svg>
+                </span>
+            </span>
+        </label>
     </div>
 
     <div class="input-field form-group">

--- a/docs/_components/form_controls/01_input.html
+++ b/docs/_components/form_controls/01_input.html
@@ -16,13 +16,7 @@ stylesheet: '/scss/elements/input-field.scss'
             Enabled invalid input
             <span class="inline-help-tooltip" title="A simple inline help text." data-placement="right">
                 <span class="inline-help-icon">
-                    <svg viewBox="0 0 20 20" class="icon fill-medium-grey">
-                        <path fill-rule="evenodd" clip-rule="evenodd"
-                              d="M10 4.6c-2 0-3.7 1.6-3.7 3.7h1.8c0-1 .8-1.8 1.8-1.8s1.8.8 1.8 1.8c0 1.8-2.8 1.6-2.8 4.6h1.8c0-2.1 2.8-2.3 2.8-4.6.2-2.1-1.5-3.7-3.5-3.7z"></path>
-                        <path d="M9.1 13.8h1.8v1.8H9.1z"></path>
-                        <path d="M10 17.2c-4 0-7.2-3.2-7.2-7.2S6 2.8 10 2.8 17.2 6 17.2 10 14 17.2 10 17.2zM10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9z"
-                              clip-rule="evenodd" fill-rule="evenodd"></path>
-                    </svg>
+                    {{ site.data.icons['help'] }}
                 </span>
             </span>
         </label>

--- a/docs/_components/form_controls/17_form-controls.html
+++ b/docs/_components/form_controls/17_form-controls.html
@@ -27,10 +27,26 @@ stylesheet: '/scss/forms/form.scss'
         </div>
     </fieldset>
 
+    <fieldset class="form-group">
+        <label class="form-control-label">A group of checkboxes</label>
+        <div class="form-control coveo-checkbox-labels-group">
+            <label class="coveo-checkbox-label">
+                <input type="checkbox" class="coveo-checkbox">
+                <button></button>
+                <span class="label">Checkbox 1</span>
+            </label>
+            <label class="coveo-checkbox-label">
+                <input type="checkbox" class="coveo-checkbox">
+                <button></button>
+                <span class="label">Checkbox 2</span>
+            </label>
+        </div>
+    </fieldset>
+
     <label class="form-group coveo-checkbox-label">
         <input type="checkbox" class="coveo-checkbox">
         <button></button>
-        <span class="label">I'm free</span>
+        <span class="label">A single checkbox (without a form-control-label)</span>
     </label>
 
     <fieldset class="form-group input-field">

--- a/docs/_includes/scripts.html
+++ b/docs/_includes/scripts.html
@@ -6,7 +6,9 @@
             inline: true,
             date: new Date()
         });
-        $('[title]').tooltip();
+        $('[title]').tooltip({
+            container: 'body'
+        });
 
         var selectedTab;
         window.onload = function() {

--- a/scss/components/tooltip.scss
+++ b/scss/components/tooltip.scss
@@ -112,6 +112,7 @@
 
     color: $pure-white;
     text-decoration: none;
+    word-wrap: break-word;
     white-space: normal;
 
     background-color: $dark-blue;

--- a/scss/controls/checkboxes.scss
+++ b/scss/controls/checkboxes.scss
@@ -124,3 +124,16 @@ input[type=checkbox].coveo-checkbox {
 label[for].coveo-checkbox-label {
   cursor: pointer;
 }
+
+.coveo-checkbox-labels-group {
+  @extend .clearfix;
+
+  .coveo-checkbox-label {
+    float: left;
+    clear: left;
+
+    & + .coveo-checkbox-label {
+      margin-top: 18px;
+    }
+  }
+}

--- a/scss/controls/input-field.scss
+++ b/scss/controls/input-field.scss
@@ -35,7 +35,6 @@
 
         color: $medium-blue;
         font-size: $form-control-label-font-size;
-        font-weight: bold;
       }
     }
 
@@ -54,6 +53,12 @@
     position: absolute;
     top: 10px;
     left: 0;
+    align-items: center;
+
+    display: flex; // Used for inline-help-tooltip placement
+
+    color: $dark-grey;
+    font-size: $input-field-font-size;
 
     transition: 0.2s all ease;
 
@@ -96,12 +101,12 @@
       &:after {
         position: absolute;
         top: 30.1px; // The .1 is a fix for Chrome. Without it, Chrome makes the element bounce... Works in all other browsers.
+        left: 0;
 
         display: block;
 
         content: '';
-        font-size: 13px;
-        font-weight: bold;
+        font-size: 12px;
 
         transition: 0.2s all ease;
 

--- a/scss/forms/block-form.scss
+++ b/scss/forms/block-form.scss
@@ -56,5 +56,9 @@ form {
       width: 1.2em;
       height: 1.2em;
     }
+
+    .inline-help-icon > svg {
+      fill: $medium-grey;
+    }
   }
 }

--- a/scss/forms/block-form.scss
+++ b/scss/forms/block-form.scss
@@ -19,7 +19,6 @@ form {
 
     color: $medium-blue;
     font-size: $form-control-label-font-size;
-    font-weight: bold;
   }
 
   .form-group {
@@ -35,6 +34,27 @@ form {
 
     &.coveo-checkbox-label, &.coveo-slide-toggle-label {
       display: flex;
+    }
+
+    &.collapsable-panel-group {
+      .panel-heading a {
+        padding-left: 18px;
+      }
+      .toggle-icon {
+        left: 0;
+      }
+    }
+  }
+
+  .inline-help-tooltip {
+    margin-left: 10px;
+
+    pointer-events: visible; // Very useful for input-fields
+
+    &, .inline-help-icon, .inline-help-icon > svg {
+      display: inline-block;
+      width: 1.2em;
+      height: 1.2em;
     }
   }
 }


### PR DESCRIPTION
* Handle inline-help-tooltip in labels
* Add coveo-checkbox-labels-group for checkboxes group
* Add word-wrap: break-word for tooltips with a long text
* No more bold for inputs label